### PR TITLE
Fix build errors when space in path for nuget pack command

### DIFF
--- a/LevelUp.Pos.ProposedOrders/LevelUp.Pos.ProposedOrders.csproj
+++ b/LevelUp.Pos.ProposedOrders/LevelUp.Pos.ProposedOrders.csproj
@@ -64,7 +64,7 @@
     <PropertyGroup>
       <NuspecSourceDirectory>$(ProjectDir)nuspec\</NuspecSourceDirectory>
       <NuspecVersion>$(GitVersion_NuGetVersion)</NuspecVersion>
-      <NuGetPackCommand>nuget pack $(NuspecSourceDirectory)ProposedOrderCalculator.nuspec -OutputDirectory $(TargetDir) -properties version=$(NuspecVersion)</NuGetPackCommand>
+      <NuGetPackCommand>nuget pack "$(NuspecSourceDirectory)ProposedOrderCalculator.nuspec" -OutputDirectory "$(TargetDir) " -properties version=$(NuspecVersion)</NuGetPackCommand>
     </PropertyGroup>
     <Message Text="$(NuGetPackCommand)" Importance="High" />
     <Exec Command="$(NuGetPackCommand)" />


### PR DESCRIPTION
So these were the changes needed for me to build the release configuration and create the nuget package successfully. As it was, I would build successfully, but without creating a nupkg in the release directory.

Little bit of a different deal here than with the powershell commands that were embedded in <Exec> tags. I tried both single and double quotes, only double worked, and also the space after $(TargetDir) is crucial to success as well.