### PR TITLE
Proposed Order Calculator - Migrated from .NET 3.0 to .NET 4.0

### DIFF
--- a/LevelUp.Pos.ProposedOrders/LevelUp.Pos.ProposedOrders.csproj
+++ b/LevelUp.Pos.ProposedOrders/LevelUp.Pos.ProposedOrders.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>LevelUp.Pos.ProposedOrders</RootNamespace>
     <AssemblyName>LevelUp.Pos.ProposedOrders.ProposedOrderCalculator</AssemblyName>
-    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/LevelUp.Pos.ProposedOrders/nuspec/ProposedOrderCalculator.nuspec
+++ b/LevelUp.Pos.ProposedOrders/nuspec/ProposedOrderCalculator.nuspec
@@ -15,7 +15,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" target="lib\net30\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" />
-    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" target="lib\net30\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" />
+    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" target="lib\net40\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" />
+    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" target="lib\net40\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" />
   </files>
 </package>


### PR DESCRIPTION
There no longer appears to be any reason the library should target .NET 3.0, particularly since the SDK now also targets .NET 4.0

Planning on merging w/o review.