### PR TITLE
Proposed Orders Calculator - Hotfix/agilysys tax inspection

### DIFF
--- a/LevelUp.Pos.ProposedOrders.Tests/LevelUp.Pos.ProposedOrders.Tests.csproj
+++ b/LevelUp.Pos.ProposedOrders.Tests/LevelUp.Pos.ProposedOrders.Tests.csproj
@@ -50,7 +50,8 @@
     <Compile Include="Data\CalculatorTestData.cs" />
     <Compile Include="CalculateAdjustedExemptionTests.cs" />
     <Compile Include="CalculateAdjustedTaxAmountTests.cs" />
-    <Compile Include="Mocks\Check.cs" />
+    <Compile Include="Mocks\PointOfSale.cs" />
+    <Compile Include="PointOfSaleTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SplitTenderTests.cs" />
     <Compile Include="UpdateExemptionAmountTests.cs" />

--- a/LevelUp.Pos.ProposedOrders.Tests/PointOfSaleTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/PointOfSaleTests.cs
@@ -1,0 +1,56 @@
+﻿using FluentAssertions;
+using LevelUp.Pos.ProposedOrders.Tests.Mocks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LevelUp.Pos.ProposedOrders.Tests
+{
+    [TestClass]
+    public class PointOfSaleTests
+    {
+        /// <summary>
+        /// Simple test with (somewhat) arbitrary values that was added when a rounding error in the PointOfSale.cs
+        /// class was discovered.
+        /// </summary>
+        [TestMethod]
+        public void PointOfSaleTests_RoundingTest1()
+        {
+            PointOfSale pointOfSale = new PointOfSale(total: 1131, tax: 74);
+
+            int exemptionAmount = 0;
+            int spendAmount = 1131;
+
+            // apply tender(s)
+            pointOfSale.ApplyTender(0);
+
+            // prepare Proposed Order call
+            AdjustedCheckValues proposedOrderValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
+                pointOfSale.TotalOutstandingAmount,
+                pointOfSale.TotalTaxAmount,
+                exemptionAmount,
+                spendAmount);
+
+            proposedOrderValues.ShouldBeEquivalentTo(new AdjustedCheckValues(
+                spendAmount: 1131,
+                taxAmount: 74,
+                exemptionAmount: 0));
+
+            // apply discount(s)
+            int availableDiscountAmount = 0;
+
+            pointOfSale.ApplyDiscount(availableDiscountAmount);
+
+            // prepare Completed Order call
+            AdjustedCheckValues completedOrderValues = ProposedOrderCalculator.CalculateCompleteOrderValues(
+                pointOfSale.TotalOutstandingAmount,
+                pointOfSale.TotalTaxAmount,
+                exemptionAmount,
+                spendAmount,
+                availableDiscountAmount);
+
+            completedOrderValues.ShouldBeEquivalentTo(new AdjustedCheckValues(
+                spendAmount: 1131,
+                taxAmount: 74,
+                exemptionAmount: 0));
+        }
+    }
+}

--- a/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
+++ b/LevelUp.Pos.ProposedOrders.Tests/SplitTenderTests.cs
@@ -34,7 +34,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             // Check details (prior to LevelUp Scan)
             //   Item subtotal: $20
             //   tax (10%):      $2
-            Check check = new Check(total: 2200, tax: 200);
+            PointOfSale check = new PointOfSale(total: 2200, tax: 200);
 
             // User pays $10 towards LevelUp
             // example does not consider exemptions
@@ -92,7 +92,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             //   Item subtotal: $20
             //   tax (10%):      $2
             //   TOTAL DUE:     $22
-            Check check = new Check(total: 2200, tax: 200);
+            PointOfSale check = new PointOfSale(total: 2200, tax: 200);
 
             // Cashier tenders $10 to cash
             // Updated check:
@@ -155,7 +155,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         {
             // $9.90 is owed, $0.90 of that is tax. $3.00 of that is tobacco/alcohol, and the customer wants to pay
             // $9.00 towards the check
-            Check check = new Check(total: 990, tax: 90);
+            PointOfSale check = new PointOfSale(total: 990, tax: 90);
             int exemptionAmount = 300;
             int spendAmount = 900;
 
@@ -217,7 +217,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         {
             // $22.00 is owed, $2.00 of that is tax. $0.00 of that is tobacco/alcohol, and the customer wants to pay
             // $12.00 towards the check all of which is discountable.
-            Check check = new Check(total: 2200, tax: 200);
+            PointOfSale check = new PointOfSale(total: 2200, tax: 200);
             int exemptionAmount = 0;
             int spendAmount = 1200;
 
@@ -280,7 +280,7 @@ namespace LevelUp.Pos.ProposedOrders.Tests
         {
             // $22.00 is owed, $2.00 of that is tax. $0.00 of that is tobacco/alcohol, and the customer wants to pay
             // $12.00 towards the check all of which is discountable.
-            Check check = new Check(total: 1060, tax: 60);
+            PointOfSale check = new PointOfSale(total: 1060, tax: 60);
             int exemptionAmount = 0;
             int spendAmount = 530;
 
@@ -320,6 +320,61 @@ namespace LevelUp.Pos.ProposedOrders.Tests
             AdjustedCheckValues completedOrderValues = ProposedOrderCalculator.CalculateCompleteOrderValues(
                 check.TotalOutstandingAmount,
                 check.TotalTaxAmount,
+                exemptionAmount,
+                spendAmount,
+                availableDiscountAmount);
+
+            completedOrderValues.ShouldBeEquivalentTo(expectedCompletedOrderValues,
+                $"Expected: {expectedCompletedOrderValues}" + Environment.NewLine +
+                $"Actual: {completedOrderValues}");
+        }
+
+        [TestMethod]
+        public void SplitTenderExample_OneCentPaid_WhenOneCentOwed()
+        {
+            // $0.02 is owed, $0.01 of that is tax. $0.00 of that is tobacco/alcohol, and the customer wants to pay
+            // $0.01 towards the check none of which is discountable (after a $0.01 cash payment).
+            PointOfSale pointOfSale = new PointOfSale(total: 2, tax: 1);
+            int exemptionAmount = 0;
+            int spendAmount = 1;
+
+            pointOfSale.ApplyTender(1);
+
+            // Create proposed order: expected values
+            AdjustedCheckValues expectedProposedOrderValues =
+                new AdjustedCheckValues(
+                    spendAmount: 1,         // amount the customer wants to pay
+                    taxAmount: 1,           // tax will be due for this payment; tax will be paid "at the end"
+                    exemptionAmount: 0);    // there are no exemptions
+
+            AdjustedCheckValues proposedOrderValues = ProposedOrderCalculator.CalculateCreateProposedOrderValues(
+                pointOfSale.TotalOutstandingAmount,
+                pointOfSale.TotalTaxAmount,
+                exemptionAmount,
+                spendAmount);
+
+            proposedOrderValues.ShouldBeEquivalentTo(expectedProposedOrderValues,
+                $"Expected: {expectedProposedOrderValues}" + Environment.NewLine +
+                $"Actual: {proposedOrderValues}");
+
+            // available discount amount $0.00
+            int availableDiscountAmount = 0;
+
+            pointOfSale.ApplyDiscount(availableDiscountAmount);
+
+            // $ 0.00 (Subtotal Remaining)
+            // $ 0.01 (Tax)
+            // $ 0.01 (Total)
+            // $ 0.01 (Total + Discount Applied) 
+            AdjustedCheckValues expectedCompletedOrderValues =
+                new AdjustedCheckValues(
+                    spendAmount: 1,
+                    taxAmount: 1,
+                    exemptionAmount: 0);
+
+            AdjustedCheckValues completedOrderValues = ProposedOrderCalculator.CalculateCompleteOrderValues(
+                pointOfSale.TotalOutstandingAmount,
+                pointOfSale.TotalTaxAmount,
                 exemptionAmount,
                 spendAmount,
                 availableDiscountAmount);


### PR DESCRIPTION
While investigating a bug for Agilysys, we realized we weren't testing the scenario where a user owed $0.01 (in a partial tender scenario) - I've added that test below, and updated some of the classes/error handling to make this a bit more readable (hopefully). 

This gist of this PR is...
* A single additional test
* Refactoring

No changes to calculations have been made here.

RFR