### PR TITLE
Fix nuspec file definitions

### DIFF
--- a/LevelUp.Pos.ProposedOrders/nuspec/ProposedOrderCalculator.nuspec
+++ b/LevelUp.Pos.ProposedOrders/nuspec/ProposedOrderCalculator.nuspec
@@ -15,7 +15,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" target="lib\net40\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" />
-    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" target="lib\net40\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" />
+    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.dll" target="lib\net40" />
+    <file src="..\bin\**\LevelUp.Pos.ProposedOrders.ProposedOrderCalculator.xml" target="lib\net40" />
   </files>
 </package>


### PR DESCRIPTION
These file definitions result in a badly formed nuget package that the new nuget flow (part of the new csproj format) rejects.